### PR TITLE
load migration condition & type hints & return type declerations & new class property

### DIFF
--- a/src/ModuleServiceProvider.php
+++ b/src/ModuleServiceProvider.php
@@ -123,6 +123,9 @@ class ModuleServiceProvider extends ServiceProvider {
 		$this->loadRoutes($modulePath);
 		$this->loadViewsFrom($modulePath->getRealPath() . '/module/resources/views', Str::kebab($modulePath->getFilename()));
 		$this->loadTranslationsFrom($modulePath->getRealPath() . '/module/resources/lang', Str::kebab($modulePath->getFilename()));
-		$this->loadMigrationsFrom($modulePath->getRealPath() . '/module/database/migrations');
+		
+		if (app()->runningInConsole()) {
+			$this->loadMigrationsFrom($modulePath->getRealPath() . '/module/database/migrations');
+		}
 	}
 }

--- a/src/ModuleServiceProvider.php
+++ b/src/ModuleServiceProvider.php
@@ -8,12 +8,14 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Modules\DependencyException;
 
-class ModuleServiceProvider extends ServiceProvider {
+class ModuleServiceProvider extends ServiceProvider
+{
+	protected static $modulesPath 	= null;
+	public static $registered     	= [];
+	protected $modulePath     		= [];
 
-	protected static $modulesPath = null;
-	public static $registered = [];
-
-	public function register() {
+	public function register()
+	{
 		static::$registered[] = static::class;
 	}
 
@@ -22,87 +24,96 @@ class ModuleServiceProvider extends ServiceProvider {
 	 *
 	 * @return void
 	 */
-	public function boot() {
+	public function boot()
+	{
 		$staticFileName = (new \ReflectionClass(static::class))->getFileName();
 		$modulePathName = substr($staticFileName, 0, strpos($staticFileName, DIRECTORY_SEPARATOR, strlen(base_path('app' . DIRECTORY_SEPARATOR . 'Modules')) + 1));
-		$modulePath = new \SplFileInfo(realpath($modulePathName));
-		$this->load($modulePath);
+		$this->modulePath     = new \SplFileInfo(realpath($modulePathName));
+		$this->load();
 	}
 
-	protected function loadRoutesToLumen($modulePath, $routesFile) {
+	protected function loadRoutesToLumen(string $routesFile) : void
+	{
 		app(\Laravel\Lumen\Routing\Router::class)->group([
-			'namespace' => '\App\Modules\\' . $modulePath->getFilename() . '\Http\Controllers',
-			'as' => Str::kebab($modulePath->getFilename()),
-			], function()use ($routesFile) {
+			'namespace' => '\App\Modules\\' . $this->modulePath->getFilename() . '\Http\Controllers',
+			'as'        => Str::kebab($this->modulePath->getFilename())
+		], function () use ($routesFile) {
 			$router = app(\Laravel\Lumen\Routing\Router::class);
-			include($routesFile);
+			include ($routesFile);
 		});
 	}
 
-	protected function loadRoutesToLaravel($modulePath, $routesFile) {
-		Route::name(Str::kebab($modulePath->getFilename()) . '::')
-			->namespace('App\Modules\\' . $modulePath->getFilename() . '\Http\Controllers')
+	protected function loadRoutesToLaravel(string $routesFile) : void
+	{
+		Route::name(Str::kebab($this->modulePath->getFilename()) . '::')
+			->namespace('App\Modules\\' . $this->modulePath->getFilename() . '\Http\Controllers')
 			->group($routesFile);
 	}
 
-	protected function loadRoutes($modulePath) {
-		$routesFile = $modulePath->getRealPath() . '/module/routes.php';
+	protected function loadRoutes() : void
+	{
+		$routesFile = $this->modulePath->getRealPath() . '/module/routes.php';
 		if (file_exists($routesFile)) {
 			if (app() instanceof \Illuminate\Foundation\Application) {
-				$this->loadRoutesToLaravel($modulePath, $routesFile);
+				$this->loadRoutesToLaravel($routesFile);
 			} else {
-				$this->loadRoutesToLumen($modulePath, $routesFile);
+				$this->loadRoutesToLumen($routesFile);
 			}
 		}
 	}
 
-	public function loadConfig($modulePath) {
-		$configDir = $modulePath->getRealPath() . '/module/config';
-		$key = 'modules.' . Str::kebab($modulePath->getFilename());
-		config([$key => ['name' => $modulePath->getFilename()]]);
+	public function loadConfig() : void
+	{
+		$configDir = $this->modulePath->getRealPath() . '/module/config';
+		$key       = 'modules.' . Str::kebab($this->modulePath->getFilename());
+		config([$key => ['name' => $this->modulePath->getFilename()]]);
 		if (is_dir($configDir)) {
 			foreach (new \FilesystemIterator($configDir, \FilesystemIterator::SKIP_DOTS) as $configFile) {
 				$configFileName = Str::kebab($configFile->getBasename('.php'));
-				if ($configFileName == 'module') {
+				if ('module' == $configFileName) {
 					$this->mergeConfigFrom($configFile->getPathname(), $key);
 				} else {
-					$config = $this->app['config']->get($configFileName, []);
-					$moduleConfig = include($configFile->getPathname());
+					$config       = $this->app['config']->get($configFileName, []);
+					$moduleConfig = include $configFile->getPathname();
 					$this->app['config']->set($configFileName, array_merge($config, $moduleConfig));
 				}
 			}
 		}
 	}
 
-	protected function loadEvents($modulePath) {
-		$eventsFile = $modulePath->getRealPath() . '/module/events.php';
+	protected function loadEvents() : void
+	{
+		$eventsFile = $this->modulePath->getRealPath() . '/module/events.php';
 		if (file_exists($eventsFile)) {
-			$subscribers = include($eventsFile);
+			$subscribers = include $eventsFile;
 			$this->loadSubscribers($subscribers ?? []);
 		}
 	}
 
-	protected function loadSubscribers($subscriberInfo) {
+	protected function loadSubscribers(array $subscriberInfo) : void
+	{
 		foreach ($subscriberInfo as $subscriber) {
 			app('events')->subscribe($subscriber);
 		}
 	}
 
-	protected function loadCommands($modulePath) {
-		$commands = [];
-		$commandsDir = $modulePath->getRealPath() . '/Console/Commands';
+	protected function loadCommands() : void
+	{
+		$commands     = [];
+		$commandsDir  = $this->modulePath->getRealPath() . '/Console/Commands';
 		$commandsPath = is_dir($commandsDir) ? new \FilesystemIterator($commandsDir, \FilesystemIterator::SKIP_DOTS) : [];
 		foreach ($commandsPath as $commandFile) {
-			$commands[] = '\App\Modules\\' . $modulePath->getFilename() . '\Console\Commands\\' . $commandFile->getBaseName('.php');
+			$commands[] = '\App\Modules\\' . $this->modulePath->getFilename() . '\Console\Commands\\' . $commandFile->getBaseName('.php');
 		}
 
 		$this->commands($commands);
 	}
 
-	protected function checkDependencies($modulePath) {
-		$dependencyPath = $modulePath->getRealPath() . '/module/dependencies.php';
-		$dependencies = file_exists($dependencyPath) ? include($dependencyPath) : [];
-		$notMet = [];
+	protected function checkDependencies() : void
+	{
+		$dependencyPath = $this->modulePath->getRealPath() . '/module/dependencies.php';
+		$dependencies   = file_exists($dependencyPath) ? include $dependencyPath : [];
+		$notMet         = [];
 		foreach ($dependencies as $dependency) {
 			if (!in_array($dependency, static::$registered)) {
 				$matches = [];
@@ -111,21 +122,24 @@ class ModuleServiceProvider extends ServiceProvider {
 			}
 		}
 		if (count($notMet)) {
-			throw new DependencyException($modulePath->getFilename(), $notMet);
+			throw new DependencyException($this->modulePath->getFilename(), $notMet);
 		}
 	}
 
-	protected function load($modulePath) {
-		$this->checkDependencies($modulePath);
-		$this->loadCommands($modulePath);
-		$this->loadConfig($modulePath);
-		$this->loadEvents($modulePath);
-		$this->loadRoutes($modulePath);
-		$this->loadViewsFrom($modulePath->getRealPath() . '/module/resources/views', Str::kebab($modulePath->getFilename()));
-		$this->loadTranslationsFrom($modulePath->getRealPath() . '/module/resources/lang', Str::kebab($modulePath->getFilename()));
-		
+	protected function load() : void
+	{
+		$realPath 		= $this->modulePath->getRealPath();
+		$kebabFilename 	= Str::kebab($this->modulePath->getFilename());
+
+		$this->checkDependencies();
+		$this->loadCommands();
+		$this->loadConfig();
+		$this->loadEvents();
+		$this->loadRoutes();
+		$this->loadViewsFrom($realPath . '/module/resources/views', $kebabFilename);
+		$this->loadTranslationsFrom($realPath . '/module/resources/lang', $kebabFilename);
 		if (app()->runningInConsole()) {
-			$this->loadMigrationsFrom($modulePath->getRealPath() . '/module/database/migrations');
+			$this->loadMigrationsFrom($realPath . '/module/database/migrations');
 		}
 	}
 }

--- a/src/ModuleServiceProvider.php
+++ b/src/ModuleServiceProvider.php
@@ -12,7 +12,7 @@ class ModuleServiceProvider extends ServiceProvider
 {
 	protected static $modulesPath 	= null;
 	public static $registered     	= [];
-	protected $modulePath     		= [];
+	protected $modulePath     	= [];
 
 	public function register()
 	{
@@ -28,7 +28,7 @@ class ModuleServiceProvider extends ServiceProvider
 	{
 		$staticFileName = (new \ReflectionClass(static::class))->getFileName();
 		$modulePathName = substr($staticFileName, 0, strpos($staticFileName, DIRECTORY_SEPARATOR, strlen(base_path('app' . DIRECTORY_SEPARATOR . 'Modules')) + 1));
-		$this->modulePath     = new \SplFileInfo(realpath($modulePathName));
+		$this->modulePath = new \SplFileInfo(realpath($modulePathName));
 		$this->load();
 	}
 
@@ -128,7 +128,7 @@ class ModuleServiceProvider extends ServiceProvider
 
 	protected function load() : void
 	{
-		$realPath 		= $this->modulePath->getRealPath();
+		$realPath 	= $this->modulePath->getRealPath();
 		$kebabFilename 	= Str::kebab($this->modulePath->getFilename());
 
 		$this->checkDependencies();


### PR DESCRIPTION
Skips loading migration files if app is not running in console to avoid loading unnecessary files since we wouldn't use them by default. Also took $modulePath variable into $this->modulePath to make it reachable later and cleared $modulePath from args of other methods. So now if user wants to specifically load migrations s/he can still go with:

```php
public function boot()
{
	parent::boot();
	$this->loadMigrationsFrom($this->modulePath->getRealPath() . '/module/database/migrations');
}
```